### PR TITLE
scan `time.Time`

### DIFF
--- a/xoutil.go
+++ b/xoutil.go
@@ -26,6 +26,9 @@ func (t SqTime) Value() (driver.Value, error) {
 // Scan satisfies the Scanner interface.
 func (t *SqTime) Scan(v interface{}) error {
 	switch x := v.(type) {
+	case time.Time:
+		t.Time = x
+		return nil
 	case []byte:
 		return t.parse(string(x))
 


### PR DESCRIPTION
go-sqlite3 sometimes, if not always, returns `time.Time` for `DATETIME` columns.
I don't know if it's because of go-sqlite3's improvement.